### PR TITLE
Debug sa design

### DIFF
--- a/R/did-check-sad.R
+++ b/R/did-check-sad.R
@@ -196,7 +196,7 @@ did_sad_pattern <- function(data, treatment, Gmat) {
                         decreasing = TRUE)
   data <- data %>%
     mutate(id_subject = factor(.data$id_subject, levels = treat_timing),
-           treatment  = ifelse(.data$treatment == 1, "treated", "control"))
+           treatment  = ifelse(!!sym(treatment) == 1, "treated", "control"))
   gg <- ggplot(data, aes(x = .data$id_time, y = .data$id_subject, fill = !!sym(treatment))) +
     geom_tile() +
     scale_fill_manual(values = c("lightgray", '#1E88A8')) +

--- a/R/did-sad.R
+++ b/R/did-sad.R
@@ -239,8 +239,20 @@ compute_did <- function(formula, dat_panel, outcome, treatment,
   for (ll in 1:length(lead)) {
     did_est <- map_dbl(est_did, ~.x[[ll]][1])
     sdid_est <- map_dbl(est_did, ~.x[[ll]][2])
-    did_vec[[ll]] <- did_est %*% (time_weight_new / sum(time_weight_new))
-    sdid_vec[[ll]] <- sdid_est %*% (time_weight_new / sum(time_weight_new))
+
+    ##
+    ## check if did_est and sdid_est has NA:
+    ##  if there are not sufficient number of post-treatment periods
+    ##  did_est/sdid_est would contain  NA.
+    ##
+    did_remove_na <- did_est[!is.na(did_est)]
+    sdid_remove_na <- sdid_est[!is.na(sdid_est)]
+    did_weight <- time_weight_new[!is.na(did_est)]
+    sdid_weight <- time_weight_new[!is.na(sdid_est)]
+    
+    ## compute time-averages
+    did_vec[[ll]] <- did_remove_na %*% (did_weight / sum(did_weight))
+    sdid_vec[[ll]] <- sdid_remove_na %*% (sdid_weight / sum(sdid_weight))
   }
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <img src="man/figures/logo.png" align="center" alt="logo" width="200" height="250"><br/><br/>
-    DIDdesign:Analyzing Difference-in-Differences Design
+    DIDdesign: Analyzing Difference-in-Differences Design
 </p>
 
 <!-- badges: start -->


### PR DESCRIPTION
## Debug functions related to the SA design

- Address an issue that estimates become `NA` when there are not sufficiently long post-treatment periods
- Address an issue in `plot()` function that produce an error when the treatment variable is named other than `treatment`

``` r
##
## Sances example 
##

require(DIDdesign)
#> Loading required package: DIDdesign
require(dplyr)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
data(sances2015)

## prepare data 
data_use <- sances2015 %>%
  mutate(id_time = year, id_subject = as.numeric(as.factor(swis_code)))

## remove observations that are treated at early time points
Dmean <- data_use %>% group_by(id_subject) %>% summarise(across(treatment, mean))
#> `summarise()` ungrouping output (override with `.groups` argument)
data_use2 <- data_use %>% 
  filter(!(id_subject %in% Dmean$id_subject[Dmean$treatment > 0.85])) %>% 
  mutate(id_subject = as.numeric(as.factor(as.character(id_subject))))

## example 
set.seed(1234)
fit_sa_dyn <- did(
  formula = reassessed ~ treatment,
  data    = data_use2,
  id_unit = "id_subject",
  id_time = "id_time",
  design  = "sa",
  option  = list(n_boot = 10, parallel = TRUE, lead = 0:5, thres = 1)
)


summary(fit_sa_dyn)
#> ── ATT Estimates ───────────────────────────────────────────────────────────────
#>        estimator lead estimate std.error statistic p_value
#> 1  SA-Double-DID    0   -1.672       9.2    -0.182 0.85580
#> 2         SA-DID    0    1.691       2.6     0.642 0.52064
#> 3        SA-sDID    0   -0.401       5.6    -0.071 0.94328
#> 4  SA-Double-DID    1   -5.110      11.0    -0.466 0.64126
#> 5         SA-DID    1    2.584       3.5     0.743 0.45762
#> 6        SA-sDID    1   -1.200       5.1    -0.235 0.81383
#> 7  SA-Double-DID    2    4.529       5.3     0.859 0.39032
#> 8         SA-DID    2    9.135       3.5     2.610 0.00906
#> 9        SA-sDID    2    4.682       5.1     0.919 0.35810
#> 10 SA-Double-DID    3   -6.555       8.9    -0.735 0.46228
#> 11        SA-DID    3   10.648       3.2     3.338 0.00084
#> 12       SA-sDID    3    0.071       5.3     0.013 0.98945
#> 13 SA-Double-DID    4   -3.202       6.1    -0.526 0.59867
#> 14        SA-DID    4   10.236       4.5     2.255 0.02412
#> 15       SA-sDID    4   -2.360       5.7    -0.414 0.67859
#> 16 SA-Double-DID    5    1.834       4.1     0.446 0.65553
#> 17        SA-DID    5    9.219       4.1     2.250 0.02447
#> 18       SA-sDID    5    0.402       4.8     0.083 0.93387

plot(fit_sa_dyn)
```

![](https://i.imgur.com/v1bjEIL.png)

<sup>Created on 2021-04-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>