### PR TITLE
Edit input names

### DIFF
--- a/R/did-sad.R
+++ b/R/did-sad.R
@@ -249,7 +249,7 @@ compute_did <- function(formula, dat_panel, outcome, treatment,
     sdid_remove_na <- sdid_est[!is.na(sdid_est)]
     did_weight <- time_weight_new[!is.na(did_est)]
     sdid_weight <- time_weight_new[!is.na(sdid_est)]
-    
+
     ## compute time-averages
     did_vec[[ll]] <- did_remove_na %*% (did_weight / sum(did_weight))
     sdid_vec[[ll]] <- sdid_remove_na %*% (sdid_weight / sum(sdid_weight))


### PR DESCRIPTION
- Update `did_sad()` function to allow for flexible names in `id_subject` and `id_time`


``` r
require(DIDdesign)
#> Loading required package: DIDdesign
require(dplyr)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
data(sances2015)

## prepare data 
## remove observations that are treated at early time points
Dmean <- sances2015 %>% group_by(swis_code) %>% 
            summarise(across(treatment, mean))
#> `summarise()` ungrouping output (override with `.groups` argument)
data_use <- sances2015 %>% 
  filter(!(swis_code %in% Dmean$swis_code[Dmean$treatment > 0.85]))

## example 
set.seed(1234)
fit_sa_dyn <- did(
  formula = reassessed ~ treatment,
  data    = data_use,
  id_unit = "swis_code",
  id_time = "year",
  design  = "sa",
  option  = list(n_boot = 10, parallel = TRUE, lead = 0:5, thres = 1)
)

summary(fit_sa_dyn)
#> ── ATT Estimates ───────────────────────────────────────────────────────────────
#>        estimator lead estimate std.error statistic p_value
#> 1  SA-Double-DID    0   -1.543       7.1    -0.217 0.82839
#> 2         SA-DID    0    1.691       2.8     0.611 0.54145
#> 3        SA-sDID    0   -0.401       4.5    -0.089 0.92898
#> 4  SA-Double-DID    1   -0.906       3.0    -0.298 0.76607
#> 5         SA-DID    1    2.584       2.2     1.173 0.24070
#> 6        SA-sDID    1   -1.200       3.3    -0.364 0.71583
#> 7  SA-Double-DID    2    2.164       6.7     0.323 0.74655
#> 8         SA-DID    2    9.135       2.9     3.153 0.00162
#> 9        SA-sDID    2    4.682       4.1     1.129 0.25872
#> 10 SA-Double-DID    3    5.646       2.2     2.576 0.00999
#> 11        SA-DID    3   10.648       3.1     3.417 0.00063
#> 12       SA-sDID    3    0.071       3.1     0.023 0.98163
#> 13 SA-Double-DID    4    3.256       2.4     1.354 0.17571
#> 14        SA-DID    4   10.236       3.2     3.197 0.00139
#> 15       SA-sDID    4   -2.360       3.5    -0.676 0.49904
#> 16 SA-Double-DID    5    5.913       2.8     2.121 0.03392
#> 17        SA-DID    5    9.219       3.9     2.340 0.01930
#> 18       SA-sDID    5    0.402       3.5     0.115 0.90815
```

<sup>Created on 2021-04-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>